### PR TITLE
Fix CodeCleanupOnSave naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/fb4rkem5vayl1u5q?svg=true)](https://ci.appveyor.com/project/madskristensen/resettoolwindows)
 
 Download the extension at the
-[Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.CodeCleanupOnSave)
+[Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.ResetToolWindow)
 or try the
 [CI build](http://vsixgallery.com/extension/MadsKristensen.ResetToolWindow/).
 

--- a/src/Options/BaseOptionModel.cs
+++ b/src/Options/BaseOptionModel.cs
@@ -13,7 +13,7 @@ using Microsoft.VisualStudio.Shell.Settings;
 using Microsoft.VisualStudio.Threading;
 using Task = System.Threading.Tasks.Task;
 
-namespace CodeCleanupOnSave
+namespace ResetToolWindows
 {
     /// <summary>
     /// A base class for specifying options

--- a/src/Options/BaseOptionPage.cs
+++ b/src/Options/BaseOptionPage.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.VisualStudio.Shell;
 
-namespace CodeCleanupOnSave
+namespace ResetToolWindows
 {
     /// <summary>
     /// A base class for a DialogPage to show in Tools -> Options.

--- a/src/Options/DialogPageProvider.cs
+++ b/src/Options/DialogPageProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace CodeCleanupOnSave
+﻿namespace ResetToolWindows
 {
     /// <summary>
     /// A provider for custom <see cref="DialogPage" /> implementations.

--- a/src/Options/GeneralOptions.cs
+++ b/src/Options/GeneralOptions.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 
-namespace CodeCleanupOnSave
+namespace ResetToolWindows
 {
     internal class GeneralOptions : BaseOptionModel<GeneralOptions>
     {

--- a/src/ResetToolWindowsPackage.cs
+++ b/src/ResetToolWindowsPackage.cs
@@ -1,5 +1,4 @@
-﻿using CodeCleanupOnSave;
-using EnvDTE;
+﻿using EnvDTE;
 using EnvDTE80;
 using Microsoft;
 using Microsoft.VisualStudio.Shell;


### PR DESCRIPTION
README.md was pointing to another extension (CodeCleanupOnSave)

And portions of the code were still under this namespace.

(c) The Dangers of Copy and Paste

:)